### PR TITLE
Add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ typings/
 # Output of 'npm pack'
 *.tgz
 
+# NPM Package Lock file
+package-lock.json
+
 # Yarn Integrity file
 .yarn-integrity
 


### PR DESCRIPTION
This is a small cleanup that helps `npm` users. “We do exist.” 😜